### PR TITLE
Nagycsaládos autóvásárlási kedvezmény törlése

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,6 @@
               <ul>
                 <li><a href="https://csalad.hu/tamogatasok/anyasagi-tamogatas">Anyasági támogatás</a></li>
                 <li><a href="https://csalad.hu/tamogatasok/kresz-vizsgadij-tamogatas">KRESZ</a></li>
-                <li><a href="https://csalad.hu/tamogatasok/utmutato-a-nagycsaladosok-autovasarlasi-tamogatasarol">Nagycsaládos autóvásárlási támogatás</a></li>
               </ul>
             </div>
              <div>


### PR DESCRIPTION
Nagycsaládosok autótámogatási programja 2023-ban megszűnt. https://24.hu/fn/gazdasag/2023/01/02/hitelek-allami-tamogatasok-valtozasok-2023/